### PR TITLE
add ContinuedEvent

### DIFF
--- a/adapter/src/debugSession.ts
+++ b/adapter/src/debugSession.ts
@@ -121,6 +121,19 @@ export class StoppedEvent extends Event implements DebugProtocol.StoppedEvent {
 	}
 }
 
+export class ContinuedEvent extends Event implements DebugProtocol.ContinuedEvent {
+	body: {
+		threadId: number;
+	};
+
+	public constructor(threadId: number) {
+		super('continued');
+		this.body = {
+			threadId: threadId
+		};
+	}
+}
+
 export class InitializedEvent extends Event implements DebugProtocol.InitializedEvent {
 	public constructor() {
 		super('initialized');

--- a/adapter/src/main.ts
+++ b/adapter/src/main.ts
@@ -6,7 +6,7 @@
 
 import {
 	DebugSession,
-	InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, ThreadEvent, BreakpointEvent,
+	InitializedEvent, TerminatedEvent, StoppedEvent, ContinuedEvent, OutputEvent, ThreadEvent, BreakpointEvent,
 	Thread, StackFrame, Scope, Variable,
 	Breakpoint, Source, ErrorDestination
 } from './debugSession';
@@ -15,7 +15,7 @@ import { Handles } from './handles';
 
 export {
 	DebugSession,
-	InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, ThreadEvent, BreakpointEvent,
+	InitializedEvent, TerminatedEvent, StoppedEvent, ContinuedEvent, OutputEvent, ThreadEvent, BreakpointEvent,
 	Thread, StackFrame, Scope, Variable,
 	Breakpoint, Source, ErrorDestination,
 	Event, Response,

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -83,6 +83,17 @@ export module DebugProtocol {
 		};
 	}
 
+	/** Event message for "continued" event type.
+		The event indicates that the execution of the debuggee has resumed without a corresponding
+		request from the debugger.
+	*/
+	export interface ContinuedEvent extends Event {
+		body: {
+			/** The thread which resumed. */
+			threadId: number;
+		};
+	}
+
 	/** Event message for "exited" event type.
 		The event indicates that the debuggee has exited.
 	*/


### PR DESCRIPTION
The VS Code debugger supports an event type "continued", indicating that the debuggee has resumed without a corresponding request from the debugger.

For example, when debugging javascript code in Chrome or Firefox, the user may reload the page while the debugger is paused, which will resume javascript execution in the browser.

Note that I'm not sure if the `threadId` property in the event's body is optional (maybe not setting this property could be interpreted by the debugger as "all threads have resumed"?). I have made it mandatory for now.