### PR TITLE
Add ability to change the value of expressions.

### DIFF
--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -1483,6 +1483,10 @@
 					"type": "integer",
 					"description": "Evaluate the expression in the scope of this stack frame. If not specified, the expression is evaluated in the global scope."
 				},
+				"value":{
+					"type":"string",
+					"description": "The optional value to set the expression to."
+				},
 				"context": {
 					"type": "string",
 					"_enum": [ "watch", "repl", "hover" ],
@@ -1518,6 +1522,10 @@
 							"indexedVariables": {
 								"type": "number",
 								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks."
+							},
+							"readOnly": {
+								"type": "boolean",
+								"description": "Indicates the expressions value can be modified."
 							}
 						},
 						"required": [ "result", "variablesReference" ]
@@ -2077,6 +2085,10 @@
 				"type": {
 					"type": "string",
 					"description": "The type of the variable's value. Typically shown in the UI when hovering over the value."
+				},
+				"readOnly": {
+					"type": "boolean",
+					"description": "Indicates the variables value can be modified."
 				},
 				"kind": {
 					"type": "string",

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -751,6 +751,8 @@ export module DebugProtocol {
 		expression: string;
 		/** Evaluate the expression in the scope of this stack frame. If not specified, the expression is evaluated in the global scope. */
 		frameId?: number;
+		/** The optional value to set the expression to. */
+		value?: string;
 		/** The context in which the evaluate request is run. Possible values are 'watch' if evaluate is run in a watch, 'repl' if run from the REPL console, or 'hover' if run from a data hover. */
 		context?: string;
 	}
@@ -772,6 +774,8 @@ export module DebugProtocol {
 				The client can use this optional information to present the variables in a paged UI and fetch them in chunks.
 			*/
 			indexedVariables?: number;
+			/** Indicates the expressions value can be modified. */
+			readOnly?: boolean;
 		};
 	}
 
@@ -1065,6 +1069,8 @@ export module DebugProtocol {
 		value: string;
 		/** The type of the variable's value. Typically shown in the UI when hovering over the value. */
 		type?: string;
+		/** Indicates the variables value can be modified. */
+		readOnly?: boolean;
 		/** Properties of a variable that can be used to determine how to render the variable in the UI. Format of the string value: TBD. */
 		kind?: string;
 		/** Optional evaluatable name of this variable which can be passed to the 'EvaluateRequest' to fetch the variable's value. */


### PR DESCRIPTION
Allow evaluate to be used to change the value of an expression using a variable's "EvaluateName"
Also optionally allow variables or expression results to be marked as read-only.

@weinand
@jacdavis @gregg-miskelly @andrewcrawley  @tzwlai
