### PR TITLE
Allow requests to specify formatting hints.

### DIFF
--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -1096,6 +1096,10 @@
 				"levels": {
 					"type": "integer",
 					"description": "The maximum number of frames to return. If levels is not specified or 0, all frames are returned."
+				},
+				"format": {
+					"$ref": "#/definitions/StackFrameFormat",
+					"description": "Specifies details on how to format the stack frames."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1213,6 +1217,10 @@
 				"count": {
 					"type": "integer",
 					"description": "The number of variables to return. If count is missing or 0, all variables are returned."
+				},
+				"format": {
+					"$ref": "#/definitions/ValueFormat",
+					"description": "Specifies details on how to format the values."
 				}
 			},
 			"required": [ "variablesReference" ]
@@ -1271,6 +1279,10 @@
 				"value": {
 					"type": "string",
 					"description": "The value of the variable."
+				},
+				"format": {
+					"$ref": "#/definitions/ValueFormat",
+					"description": "Specifies details on the format of the value."
 				}
 			},
 			"required": [ "variablesReference", "name", "value" ]
@@ -1487,6 +1499,10 @@
 					"type": "string",
 					"_enum": [ "watch", "repl", "hover" ],
 					"description": "The context in which the evaluate request is run. Possible values are 'watch' if evaluate is run in a watch, 'repl' if run from the REPL console, or 'hover' if run from a data hover."
+				},
+				"format": {
+					"$ref": "#/definitions/ValueFormat",
+					"description": "Specifies details on how to format the result."
 				}
 			},
 			"required": [ "expression" ]
@@ -2287,6 +2303,51 @@
 				}
 			},
 			"required": [ "algorithm", "checksum" ]
+		},
+
+		"ValueFormat": {
+			"type": "object",
+			"description": "Provides formatting information for a value.",
+			"properties": {
+				"hex": {
+					"type": "boolean",
+					"description": "Displays the value in hex."
+				}
+			}
+		},
+
+		"StackFrameFormat": {
+			"allOf": [ { "$ref": "#/definitions/ValueFormat" }, {
+				"type": "object",
+				"description": "Provides formatting information for a stack frame.",
+				"properties": {
+					"parameters": {
+						"type": "boolean",
+						"description": "Displays parameters for the stack frame."
+					},
+					"parameterTypes": {
+						"type": "boolean",
+						"description": "Displays the types of parameters for the stack frame."
+					},
+					"parameterNames": {
+						"type": "boolean",
+						"description": "Displays the names of parameters for the stack frame."
+					},
+					"parameterValues": {
+						"type": "boolean",
+						"description": "Displays the values of parameters for the stack frame."
+					},
+					"line": {
+						"type": "boolean",
+						"description": "Displays the line number of the stack frame."
+					},
+					"module": {
+						"type": "boolean",
+						"description": "Displays the module of the stack frame."
+					}
+				}
+			}]
 		}
+
 	}
 }

--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -1279,10 +1279,6 @@
 				"value": {
 					"type": "string",
 					"description": "The value of the variable."
-				},
-				"format": {
-					"$ref": "#/definitions/ValueFormat",
-					"description": "Specifies details on the format of the value."
 				}
 			},
 			"required": [ "variablesReference", "name", "value" ]

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -570,6 +570,8 @@ export module DebugProtocol {
 		startFrame?: number;
 		/** The maximum number of frames to return. If levels is not specified or 0, all frames are returned. */
 		levels?: number;
+		/** Specifies details on how to format the stack frames. */
+		format?: StackFrameFormat;
 	}
 
 	/** Response to 'stackTrace' request. */
@@ -625,6 +627,8 @@ export module DebugProtocol {
 		start?: number;
 		/** The number of variables to return. If count is missing or 0, all variables are returned. */
 		count?: number;
+		/** Specifies details on how to format the values. */
+		format?: ValueFormat;
 	}
 
 	/** Response to 'variables' request. */
@@ -651,6 +655,8 @@ export module DebugProtocol {
 		name: string;
 		/** The value of the variable. */
 		value: string;
+		/** Specifies details on the format of the value. */
+		format?: ValueFormat;
 	}
 
 	/** Response to 'setVariable' request. */
@@ -753,6 +759,8 @@ export module DebugProtocol {
 		frameId?: number;
 		/** The context in which the evaluate request is run. Possible values are 'watch' if evaluate is run in a watch, 'repl' if run from the REPL console, or 'hover' if run from a data hover. */
 		context?: string;
+		/** Specifies details on how to format the result. */
+		format?: ValueFormat;
 	}
 
 	/** Response to 'evaluate' request. */
@@ -1176,6 +1184,28 @@ export module DebugProtocol {
 		algorithm: ChecksumAlgorithm;
 		/** Value of the checksum. */
 		checksum: string;
+	}
+
+	/** Provides formatting information for a value. */
+	export interface ValueFormat {
+		/** Displays the value in hex. */
+		hex?: boolean;
+	}
+
+	/** Provides formatting information for a stack frame. */
+	export interface StackFrameFormat extends ValueFormat {
+		/** Displays parameters for the stack frame. */
+		parameters?: boolean;
+		/** Displays the types of parameters for the stack frame. */
+		parameterTypes?: boolean;
+		/** Displays the names of parameters for the stack frame. */
+		parameterNames?: boolean;
+		/** Displays the values of parameters for the stack frame. */
+		parameterValues?: boolean;
+		/** Displays the line number of the stack frame. */
+		line?: boolean;
+		/** Displays the module of the stack frame. */
+		module?: boolean;
 	}
 }
 

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -655,8 +655,6 @@ export module DebugProtocol {
 		name: string;
 		/** The value of the variable. */
 		value: string;
-		/** Specifies details on the format of the value. */
-		format?: ValueFormat;
 	}
 
 	/** Response to 'setVariable' request. */


### PR DESCRIPTION
Add optional formatting object to allow customization on how values and stack frames are displayed.

@weinand
@jacdavis @gregg-miskelly @andrewcrawley  @tzwlai
