### PR TITLE
Allow setting a custom start handle

### DIFF
--- a/adapter/src/handles.ts
+++ b/adapter/src/handles.ts
@@ -10,8 +10,8 @@ export class Handles<T> {
 	private _nextHandle : number;
 	private _handleMap = new Map<number, T>();
 
-	public constructor() {
-		this._nextHandle = this.START_HANDLE;
+	public constructor(startHandle?: number) {
+		this._nextHandle = typeof startHandle === 'number' ? startHandle : this.START_HANDLE;
 	}
 
 	public reset(): void {


### PR DESCRIPTION
Possibility for fixing Microsoft/vscode-node-debug#114. I could have two handles for variables, one for locals that starts at 0 and gets reset when needed, another that starts at 100,000 for things in the console and doesn't get reset. Then when the adapter gets a variables request, it checks both handles. What do you think?