### PR TITLE
Add value formatting to customize set variables response

### DIFF
--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -1351,6 +1351,10 @@
 				"value": {
 					"type": "string",
 					"description": "The value of the variable."
+				},
+				"format": {
+					"$ref": "#/definitions/ValueFormat",
+					"description": "Specifies details on how to format the response value."
 				}
 			},
 			"required": [ "variablesReference", "name", "value" ]

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -698,6 +698,8 @@ export module DebugProtocol {
 		name: string;
 		/** The value of the variable. */
 		value: string;
+		/** Specifies details on how to format the response value. */
+		format?: ValueFormat;
 	}
 
 	/** Response to 'setVariable' request. */


### PR DESCRIPTION
I missed this case in #82. This specifies the format of the value in the response of set variable.

@weinand
@jacdavis @gregg-miskelly @andrewcrawley @tzwlai