### PR TITLE
Protocol schema: ChecksumAlgorithm Edit

### DIFF
--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -2371,7 +2371,7 @@
 		"ChecksumAlgorithm": {
 			"type": "string",
 			"description": "Names of checksum algorithms that may be supported by a debug adapter.",
-			"enum": [ "MD5", "SHA1", "SHA256", "SHA1Normalized", "SHA256Normalized", "timestamp" ]
+			"enum": [ "MD5", "SHA1", "SHA256", "timestamp" ]
 		},
 
 		"Checksum": {

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -1225,7 +1225,7 @@ export module DebugProtocol {
 	export type CompletionItemType = 'method' | 'function' | 'constructor' | 'field' | 'variable' | 'class' | 'interface' | 'module' | 'property' | 'unit' | 'value' | 'enum' | 'keyword' | 'snippet' | 'text' | 'color' | 'file' | 'reference' | 'customcolor';
 
 	/** Names of checksum algorithms that may be supported by a debug adapter. */
-	export type ChecksumAlgorithm = 'MD5' | 'SHA1' | 'SHA256' | 'SHA1Normalized' | 'SHA256Normalized' | 'timestamp';
+	export type ChecksumAlgorithm = 'MD5' | 'SHA1' | 'SHA256' | 'timestamp';
 
 	/** The checksum of an item calculated by the specified algorithm. */
 	export interface Checksum {


### PR DESCRIPTION
Removing SHA1Normalized and SHA256Normalized in ChecksumAlgorithms

Protocol only needs to know what type of hash algorithm was used, not if checksum calculated was specifically for LF or CRLF. 