### PR TITLE
Implement LoggingDebugSession

### DIFF
--- a/adapter/src/debugSession.ts
+++ b/adapter/src/debugSession.ts
@@ -263,7 +263,7 @@ export class DebugSession extends ProtocolServer {
 	private _clientColumnsStartAt1: boolean;
 	private _clientPathsAreURIs: boolean;
 
-	private _isServer: boolean;
+	protected _isServer: boolean;
 
 	public constructor(obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean) {
 		super();

--- a/adapter/src/logger.ts
+++ b/adapter/src/logger.ts
@@ -1,0 +1,168 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as fs from 'fs';
+import {OutputEvent} from './debugSession';
+
+export enum LogLevel {
+    Verbose = 0,
+    Log = 1,
+    Error = 2
+}
+
+export type ILogCallback = (outputEvent: OutputEvent) => void;
+
+interface ILogItem {
+    msg: string;
+    level: LogLevel;
+}
+
+/** Logger singleton */
+let _logger: Logger;
+let _pendingLogQ: ILogItem[] = [];
+export function log(msg: string, forceLog = false, level = LogLevel.Log): void {
+    msg = msg + '\n';
+    write(msg, forceLog, level);
+}
+
+export function verbose(msg: string): void {
+    log(msg, undefined, LogLevel.Verbose);
+}
+
+export function error(msg: string, forceLog = true): void {
+    log(msg, forceLog, LogLevel.Error);
+}
+
+/**
+ * `log` adds a newline, this one doesn't
+ */
+function write(msg: string, forceLog = false, level = LogLevel.Log): void {
+    // [null, undefined] => string
+    msg = msg + '';
+    if (_pendingLogQ) {
+        _pendingLogQ.push({ msg, level });
+    } else {
+        _logger.log(msg, level, forceLog);
+    }
+}
+
+/**
+ * Set the logger's minimum level to log. Log messages are queued before this is
+ * called the first time, because minLogLevel defaults to Error.
+ */
+export function setMinLogLevel(logLevel: LogLevel): void {
+    if (_logger) {
+        _logger.minLogLevel = logLevel;
+
+        // Clear out the queue of pending messages
+        if (_pendingLogQ) {
+            const logQ = _pendingLogQ;
+            _pendingLogQ = null;
+            logQ.forEach(item => write(item.msg, undefined, item.level));
+        }
+    }
+}
+
+export function init(logCallback: ILogCallback, logFilePath?: string, logToConsole?: boolean): void {
+    // Re-init, create new global Logger
+    _pendingLogQ = [];
+    _logger = new Logger(logCallback, logFilePath, logToConsole);
+    if (logFilePath) {
+        log(`Verbose logs are written to:`);
+        log(logFilePath);
+
+        const d = new Date();
+        const timestamp = d.toLocaleTimeString() + ', ' + d.toLocaleDateString();
+        verbose(timestamp);
+    }
+}
+
+/**
+ * Manages logging, whether to console.log, file, or VS Code console.
+ */
+class Logger {
+    /** The path of the log file */
+    private _logFilePath: string;
+
+    private _minLogLevel: LogLevel;
+    private _logToConsole: boolean;
+
+    /** Log info that meets minLogLevel is sent to this callback. */
+    private _logCallback: ILogCallback;
+
+    /** Write steam for log file */
+    private _logFileStream: fs.WriteStream;
+
+    public get minLogLevel(): LogLevel { return this._minLogLevel; }
+
+    public set minLogLevel(logLevel: LogLevel) {
+        this._minLogLevel = logLevel;
+
+        // Open a log file in the specified location. Overwritten on each run.
+        if (logLevel < LogLevel.Error && this._logFilePath) {
+            this._logFileStream = fs.createWriteStream(this._logFilePath);
+            this._logFileStream.on('error', e => {
+                this.sendLog(`Error involving log file at path: ${this._logFilePath}. Error: ${e.toString()}`, LogLevel.Error);
+            });
+        }
+    }
+
+    constructor(logCallback: ILogCallback, logFilePath?: string, isServer?: boolean) {
+        this._logCallback = logCallback;
+        this._logFilePath = logFilePath;
+        this._logToConsole = isServer;
+
+        this.minLogLevel = LogLevel.Error;
+    }
+
+    /**
+     * @param forceLog - Writes to the diagnostic logging channel, even if diagnostic logging is not enabled.
+     *      (For messages that appear whether logging is enabled or not.)
+     */
+    public log(msg: string, level: LogLevel, forceLog: boolean): void {
+        if (level >= this.minLogLevel || forceLog) {
+            this.sendLog(msg, level);
+        }
+
+        if (this._logToConsole) {
+            const logFn = level === LogLevel.Error ? console.error : console.log;
+            logFn(trimLastNewline(msg));
+        }
+
+        // If an error, prepend with '[Error]'
+        if (level === LogLevel.Error) {
+            msg = `[${LogLevel[level]}] ${msg}`;
+        }
+
+        if (this._logFileStream) {
+            this._logFileStream.write(msg);
+        }
+    }
+
+    private sendLog(msg: string, level: LogLevel): void {
+        // Truncate long messages, they can hang VS Code
+        if (msg.length > 1500) {
+            const endsInNewline = !!msg.match(/(\n|\r\n)$/);
+            msg = msg.substr(0, 1500) + '[...]';
+            if (endsInNewline) {
+                msg = msg + '\n';
+            }
+        }
+
+        if (this._logCallback) {
+            const event = new LogOutputEvent(msg, level);
+            this._logCallback(event);
+        }
+    }
+}
+
+export class LogOutputEvent extends OutputEvent {
+	constructor(msg: string, level: LogLevel) {
+		super(msg, level === LogLevel.Error ? 'stderr' : 'console');
+	}
+}
+
+export function trimLastNewline(str: string): string {
+    return str.replace(/(\n|\r\n)$/, '');
+}

--- a/adapter/src/loggingDebugSession.ts
+++ b/adapter/src/loggingDebugSession.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {DebugProtocol} from 'vscode-debugprotocol';
+
+import * as logger from './logger';
+import {DebugSession} from './debugSession';
+
+export class LoggingDebugSession extends DebugSession {
+	public constructor(private _logFilePath: string, obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean) {
+		super(obsolete_debuggerLinesAndColumnsStartAt1, obsolete_isServer);
+	}
+
+	public start(inStream: NodeJS.ReadableStream, outStream: NodeJS.WritableStream): void {
+		super.start(inStream, outStream);
+		logger.init(e => this.sendEvent(e), this._logFilePath, this._isServer);
+	}
+
+	/**
+     * Overload sendEvent to log
+     */
+    public sendEvent(event: DebugProtocol.Event): void {
+        if (!(event instanceof logger.LogOutputEvent)) {
+            // Don't create an infinite loop...
+            logger.verbose(`To client: ${JSON.stringify(event)}`);
+        }
+
+        super.sendEvent(event);
+    }
+
+    /**
+     * Overload sendRequest to log
+     */
+    public sendRequest(command: string, args: any, timeout: number, cb: (response: DebugProtocol.Response) => void): void {
+        logger.verbose(`To client: ${JSON.stringify(command)}(${JSON.stringify(args)}), timeout: ${timeout}`);
+        super.sendRequest(command, args, timeout, cb);
+    }
+
+    /**
+     * Overload sendResponse to log
+     */
+    public sendResponse(response: DebugProtocol.Response): void {
+        logger.verbose(`To client: ${JSON.stringify(response)}`);
+        super.sendResponse(response);
+    }
+
+	protected dispatchRequest(request: DebugProtocol.Request): void {
+		logger.verbose(`From client: ${request.command}(${JSON.stringify(request.arguments) })`);
+		super.dispatchRequest(request);
+	}
+}

--- a/adapter/src/main.ts
+++ b/adapter/src/main.ts
@@ -11,11 +11,15 @@ import {
 	Breakpoint, Source, Module, CompletionItem,
 	ErrorDestination
 } from './debugSession';
+import {LoggingDebugSession} from './loggingDebugSession';
+import * as Logger from './logger';
 import { Event, Response } from './messages';
 import { Handles } from './handles';
 
 export {
 	DebugSession,
+	LoggingDebugSession,
+	Logger,
 	InitializedEvent, TerminatedEvent, StoppedEvent, ContinuedEvent, OutputEvent, ThreadEvent, BreakpointEvent, ModuleEvent,
 	Thread, StackFrame, Scope, Variable,
 	Breakpoint, Source, Module, CompletionItem,


### PR DESCRIPTION
This is copying the logger code from vscode-debug-logger, and the DebugSession code from vscode-chrome-debug-core. I would still call this an experiment - I think the interface with the logger could be tweaked, and could use a third-party logging library like Winston.

A subclass of LoggingDebugSession needs to 
- Pass the logPath to the constructor
- Handle its own launch args and call Logger.setMinLogLevel, if logging is enabled. So it can name its launch arg whatever it wants.
- Make whatever additional log calls that it wants.

LoggingDebugSession will log all traffic between the debug adapter and vscode, and do everything that https://github.com/roblourens/vscode-debug-logger/blob/master/README.md says it will do.