### PR TITLE
Support for getting information about a thrown exception

### DIFF
--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -1792,10 +1792,10 @@
 				"properties": {
 					"command": {
 						"type": "string",
-						"enum": [ "completions" ]
+						"enum": [ "exceptionInfo" ]
 					},
 					"arguments": {
-						"$ref": "#/definitions/CompletionsArguments"
+						"$ref": "#/definitions/ExceptionInfoArguments"
 					}
 				},
 				"required": [ "command", "arguments"  ]

--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -1785,6 +1785,65 @@
 			}]
 		},
 
+		"ExceptionInfoRequest": {
+			"allOf": [ { "$ref": "#/definitions/Request" }, {
+				"type": "object",
+				"description": "ExceptionInfoRequest request; value of command field is 'exceptionInfo'.\nRetrieves the details of the exception that caused the StoppedEvent to be raised.",
+				"properties": {
+					"command": {
+						"type": "string",
+						"enum": [ "completions" ]
+					},
+					"arguments": {
+						"$ref": "#/definitions/CompletionsArguments"
+					}
+				},
+				"required": [ "command", "arguments"  ]
+			}]
+		},
+		"ExceptionInfoArguments": {
+			"type": "object",
+			"description": "Arguments for 'exceptionInfo' request.",
+			"properties": {
+				"threadId": {
+					"type": "integer",
+					"description": "Thread for which exception information should be retrieved."
+				}
+			},
+			"required": [ "threadId" ]
+		},
+		"ExceptionInfoResponse": {
+			"allOf": [ { "$ref": "#/definitions/Response" }, {
+				"type": "object",
+				"description": "Response to 'exceptionInfo' request.",
+				"properties": {
+					"body": {
+						"type": "object",
+						"properties": {
+							"exceptionId": {
+								"type": "string",
+								"description": "ID of the exception that was thrown."
+							},
+							"description": {
+								"type": "string",
+								"description": "Descriptive text for the exception provided by the debug adapter."
+							},
+							"breakMode": {
+								"$ref": "#/definitions/ExceptionBreakMode",
+								"description": "Mode that caused the exception notification to be raised."
+							},
+							"details": {
+								"$ref": "#/definitions/ExceptionDetails",
+								"description": "Detailed information about the exception."
+							}
+						},
+						"required": [ "exceptionId", "breakMode" ]
+					}
+				},
+				"required": [ "body" ]
+			}]
+		},
+
 		"Capabilities": {
 			"type": "object",
 			"description": "Information about the capabilities of a debug adapter.",
@@ -1869,6 +1928,10 @@
 				"supportsValueFormattingOptions": {
 					"type": "boolean",
 					"description": "The debug adapter supports a 'format' attribute on the stackTraceRequest, variablesRequest, and evaluateRequest."
+				},
+				"supportsExceptionInfoRequest": {
+					"type": "boolean",
+					"description": "The debug adapter supports the exceptionInfo request."
 				}
 			}
 		},
@@ -2481,6 +2544,41 @@
 				}
 			},
 			"required": [ "names" ]
+		},
+
+		"ExceptionDetails": {
+			"type": "object",
+			"description": "Detailed information about an exception that has occurred.",
+			"properties": {
+				"message": {
+					"type": "string",
+					"description": "Message contained in the exception."
+				},
+				"typeName": {
+					"type": "string",
+					"description": "Short type name of the exception object."
+				},
+				"fullTypeName": {
+					"type": "string",
+					"description": "Fully-qualified type name of the exception object."
+				},
+				"evaluateName": {
+					"type": "string",
+					"description": "Optional expression that can be evaluated in the current scope to obtain the exception object."
+				},
+				"stackTrace": {
+					"type": "string",
+					"description": "Stack trace at the time the exception was thrown."
+				},
+				"innerException": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/ExceptionDetails"
+					},
+					"description": "Details of the exception contained by this exception, if any."
+				}
+			}
 		}
+
 	}
 }

--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -2357,10 +2357,11 @@
 				},
 				"start": {
 					"type": "integer",
-					"description": "When a completion is selected it replaces 'length' characters starting at 'start' in the text passed to the CompletionsRequest.\nIf missing the frontend will try to determine these values heuristically."
+					"description": "If specified, this value determines the location (in the CompletionsRequest's 'text' attribute) where the completion text is added.\nIf missing the text is added at the location specified by the CompletionsRequest's 'column' attribute."
 				},
 				"length": {
-					"type": "integer"
+					"type": "integer",
+					"description": "If specified, this value determines how many characters are overwritten by the completion text.\nIf missing all text to the right of the CompletionsRequest's 'column' attribute is replaced."
 				}
 			},
 			"required": [ "label" ]

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -9,6 +9,7 @@ This npm module contains declarations for the json-based Visual Studio Code debu
 
 * 1.17.x:
   * Adds optional attribute `clientID` to the `InitializeRequestArguments`.
+  * Adds support for obtaining exception details: `ExceptionInfoRequest`, `ExceptionDetails`.
 
 * 1.16.x:
   * Updated comments for `path` and `sourceReference` attributes of `Source` type (the frontend no longer needs to have a notion of 'internal' modules; it just loads the content of a Source either through the sourceReference or the path).

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -907,6 +907,34 @@ export module DebugProtocol {
 		};
 	}
 
+	/** ExceptionInfoRequest request; value of command field is 'exceptionInfo'.
+		Retrieves the details of the exception that caused the StoppedEvent to be raised.
+	*/
+	export interface ExceptionInfoRequest extends Request {
+		// command: 'completions';
+		arguments: ExceptionInfoArguments;
+	}
+
+	/** Arguments for 'exceptionInfo' request. */
+	export interface ExceptionInfoArguments {
+		/** Thread for which exception information should be retrieved. */
+		threadId: number;
+	}
+
+	/** Response to 'exceptionInfo' request. */
+	export interface ExceptionInfoResponse extends Response {
+		body: {
+			/** ID of the exception that was thrown. */
+			exceptionId: string;
+			/** Descriptive text for the exception provided by the debug adapter. */
+			description?: string;
+			/** Mode that caused the exception notification to be raised. */
+			breakMode: ExceptionBreakMode;
+			/** Detailed information about the exception. */
+			details?: ExceptionDetails;
+		};
+	}
+
 	/** Information about the capabilities of a debug adapter. */
 	export interface Capabilities {
 		/** The debug adapter supports the configurationDoneRequest. */
@@ -945,6 +973,8 @@ export module DebugProtocol {
 		supportsExceptionOptions?: boolean;
 		/** The debug adapter supports a 'format' attribute on the stackTraceRequest, variablesRequest, and evaluateRequest. */
 		supportsValueFormattingOptions?: boolean;
+		/** The debug adapter supports the exceptionInfo request. */
+		supportsExceptionInfoRequest?: boolean;
 	}
 
 	/** An ExceptionBreakpointsFilter is shown in the UI as an option for configuring how exceptions are dealt with. */
@@ -980,9 +1010,9 @@ export module DebugProtocol {
 	/** A Module object represents a row in the modules view.
 		Two attributes are mandatory: an id identifies a module in the modules view and is used in a ModuleEvent for identifying a module for adding, updating or deleting.
 		The name is used to minimally render the module in the UI.
-		
+
 		Additional attributes can be added to the module. They will show up in the module View if they have a corresponding ColumnDescriptor.
-		
+
 		To avoid an unnecessary proliferation of additional attributes with similar semantics but different names
 		we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.
 	*/
@@ -993,7 +1023,7 @@ export module DebugProtocol {
 		name: string;
 		/** optional but recommended attributes.
 			always try to use these first before introducing additional attributes.
-			
+
 			Logical full path to the module. The exact definition is implementation defined, but usually this would be a full path to the on-disk file for the module.
 		*/
 		path?: string;
@@ -1284,6 +1314,22 @@ export module DebugProtocol {
 		negate?: boolean;
 		/** Depending on the value of 'negate' the names that should match or not match. */
 		names: string[];
+	}
+
+	/** Detailed information about an exception that has occurred. */
+	export interface ExceptionDetails {
+		/** Message contained in the exception. */
+		message?: string;
+		/** Short type name of the exception object. */
+		typeName?: string;
+		/** Fully-qualified type name of the exception object. */
+		fullTypeName?: string;
+		/** Optional expression that can be evaluated in the current scope to obtain the exception object. */
+		evaluateName?: string;
+		/** Stack trace at the time the exception was thrown. */
+		stackTrace?: string;
+		/** Details of the exception contained by this exception, if any. */
+		innerException?: ExceptionDetails[];
 	}
 }
 

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -1216,10 +1216,13 @@ export module DebugProtocol {
 		text?: string;
 		/** The item's type. Typically the client uses this information to render the item in the UI with an icon. */
 		type?: CompletionItemType;
-		/** When a completion is selected it replaces 'length' characters starting at 'start' in the text passed to the CompletionsRequest.
-			If missing the frontend will try to determine these values heuristically.
+		/** If specified, this value determines the location (in the CompletionsRequest's 'text' attribute) where the completion text is added.
+			If missing the text is added at the location specified by the CompletionsRequest's 'column' attribute.
 		*/
 		start?: number;
+		/** If specified, this value determines how many characters are overwritten by the completion text.
+			If missing all text to the right of the CompletionsRequest's 'column' attribute is replaced.
+		*/
 		length?: number;
 	}
 

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -911,7 +911,7 @@ export module DebugProtocol {
 		Retrieves the details of the exception that caused the StoppedEvent to be raised.
 	*/
 	export interface ExceptionInfoRequest extends Request {
-		// command: 'completions';
+		// command: 'exceptionInfo';
 		arguments: ExceptionInfoArguments;
 	}
 
@@ -1010,9 +1010,9 @@ export module DebugProtocol {
 	/** A Module object represents a row in the modules view.
 		Two attributes are mandatory: an id identifies a module in the modules view and is used in a ModuleEvent for identifying a module for adding, updating or deleting.
 		The name is used to minimally render the module in the UI.
-
+		
 		Additional attributes can be added to the module. They will show up in the module View if they have a corresponding ColumnDescriptor.
-
+		
 		To avoid an unnecessary proliferation of additional attributes with similar semantics but different names
 		we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.
 	*/
@@ -1023,7 +1023,7 @@ export module DebugProtocol {
 		name: string;
 		/** optional but recommended attributes.
 			always try to use these first before introducing additional attributes.
-
+			
 			Logical full path to the module. The exact definition is implementation defined, but usually this would be a full path to the on-disk file for the module.
 		*/
 		path?: string;


### PR DESCRIPTION
Here are my deviations from the original request:
- moved `supportsExceptionInfoRequest` from the `InitializeRequestArguments` to the `Capabilities` types (the client should only call the 'exceptionInfo' request if it is supported).
- `innerException` is an array of `ExceptionDetails` (as suggested by @DavidKarlas)
- renamed `objectExpression` to `evaluateName` because that's the name used in the Variable type for the identical purpose.
- I did not include the ExceptionDetails.formattedDescription, ExceptionDetails.hresult, ExceptionDetails.source, and ExceptionInfoResponse.code attributes since they appear to be not broadly useful. I suggest to introduce them as private protocol additions.