### PR TITLE
Add 'entry' stop reason

### DIFF
--- a/debugProtocol.json
+++ b/debugProtocol.json
@@ -129,8 +129,8 @@
 						"properties": {
 							"reason": {
 								"type": "string",
-								"description": "The reason for the event (such as: 'step', 'breakpoint', 'exception', 'pause'). This string is shown in the UI.",
-								"_enum": [ "step", "breakpoint", "exception", "pause" ]
+								"description": "The reason for the event (such as: 'step', 'breakpoint', 'exception', 'pause', 'entry'). This string is shown in the UI.",
+								"_enum": [ "step", "breakpoint", "exception", "pause", "entry" ]
 							},
 							"threadId": {
 								"type": "integer",

--- a/protocol/src/debugProtocol.ts
+++ b/protocol/src/debugProtocol.ts
@@ -73,7 +73,7 @@ export module DebugProtocol {
 	export interface StoppedEvent extends Event {
 		// event: 'stopped';
 		body: {
-			/** The reason for the event (such as: 'step', 'breakpoint', 'exception', 'pause'). This string is shown in the UI. */
+			/** The reason for the event (such as: 'step', 'breakpoint', 'exception', 'pause', 'entry'). This string is shown in the UI. */
 			reason: string;
 			/** The thread which was stopped. */
 			threadId?: number;


### PR DESCRIPTION
The `entry` stop reason is used in the node2 debug adapter but not present in the protocol.
Here is a snippet of the message sent by the debug adapter to the clients when stopping on entry:

`{"seq":0,"type":"event","event":"stopped","body":{"reason":"entry","threadId":1}}`