### PR TITLE
Allow setting log file path with logger setup()

### DIFF
--- a/adapter/src/logger.ts
+++ b/adapter/src/logger.ts
@@ -82,6 +82,11 @@ export class Logger {
 		// Re-init, create new global Logger
 		this._pendingLogQ = this._pendingLogQ || [];
 		this._currentLogger = new InternalLogger(logCallback, logToConsole);
+
+		// Log the date at the top
+		const d = new Date();
+		const timestamp = d.toLocaleTimeString() + ', ' + d.toLocaleDateString();
+		this.verbose(timestamp);
 	}
 }
 
@@ -124,7 +129,6 @@ class InternalLogger {
 	}
 
 	public log(msg: string, level: LogLevel): void {
-
 		if (this._minLogLevel === LogLevel.Stop) {
 			return;
 		}

--- a/adapter/src/logger.ts
+++ b/adapter/src/logger.ts
@@ -28,6 +28,8 @@ export interface ILogger {
 }
 
 export class Logger {
+	private _logFilePathFromInit: string;
+
 	private _currentLogger: InternalLogger;
 	private _pendingLogQ: ILogItem[] = [];
 
@@ -65,7 +67,11 @@ export class Logger {
 	 * Set the logger's minimum level to log in the console, and whether to log to the file. Log messages are queued before this is
 	 * called the first time, because minLogLevel defaults to Warn.
 	 */
-	setup(consoleMinLogLevel: LogLevel, logFilePath?: string): void {
+	setup(consoleMinLogLevel: LogLevel, _logFilePath?: string|boolean): void {
+		const logFilePath = typeof _logFilePath === 'string' ?
+			_logFilePath :
+			(_logFilePath && this._logFilePathFromInit);
+
 		if (this._currentLogger) {
 			this._currentLogger.setup(consoleMinLogLevel, logFilePath);
 
@@ -78,10 +84,11 @@ export class Logger {
 		}
 	}
 
-	init(logCallback: ILogCallback, logToConsole?: boolean): void {
+	init(logCallback: ILogCallback, logFilePath?: string, logToConsole?: boolean): void {
 		// Re-init, create new global Logger
 		this._pendingLogQ = this._pendingLogQ || [];
 		this._currentLogger = new InternalLogger(logCallback, logToConsole);
+		this._logFilePathFromInit = logFilePath;
 
 		// Log the date at the top
 		const d = new Date();

--- a/adapter/src/logger.ts
+++ b/adapter/src/logger.ts
@@ -65,9 +65,9 @@ export class Logger {
 	 * Set the logger's minimum level to log in the console, and whether to log to the file. Log messages are queued before this is
 	 * called the first time, because minLogLevel defaults to Warn.
 	 */
-	setup(consoleMinLogLevel: LogLevel, logToFile: boolean): void {
+	setup(consoleMinLogLevel: LogLevel, logFilePath?: string): void {
 		if (this._currentLogger) {
-			this._currentLogger.setup(consoleMinLogLevel, logToFile);
+			this._currentLogger.setup(consoleMinLogLevel, logFilePath);
 
 			// Now that we have a minimum logLevel, we can clear out the queue of pending messages
 			if (this._pendingLogQ) {
@@ -78,15 +78,10 @@ export class Logger {
 		}
 	}
 
-	init(logCallback: ILogCallback, logFilePath?: string, logToConsole?: boolean): void {
+	init(logCallback: ILogCallback, logToConsole?: boolean): void {
 		// Re-init, create new global Logger
 		this._pendingLogQ = this._pendingLogQ || [];
-		this._currentLogger = new InternalLogger(logCallback, logFilePath, logToConsole);
-		if (logFilePath) {
-			const d = new Date();
-			const timestamp = d.toLocaleTimeString() + ', ' + d.toLocaleDateString();
-			this.verbose(timestamp);
-		}
+		this._currentLogger = new InternalLogger(logCallback, logToConsole);
 	}
 }
 
@@ -97,9 +92,6 @@ export const logger = new Logger();
  * Encapsulates the state specific to each logging session
  */
 class InternalLogger {
-	/** The path of the log file */
-	private _logFilePath: string;
-
 	private _minLogLevel: LogLevel;
 	private _logToConsole: boolean;
 
@@ -109,25 +101,24 @@ class InternalLogger {
 	/** Write steam for log file */
 	private _logFileStream: fs.WriteStream;
 
-	constructor(logCallback: ILogCallback, logFilePath?: string, isServer?: boolean) {
+	constructor(logCallback: ILogCallback, isServer?: boolean) {
 		this._logCallback = logCallback;
-		this._logFilePath = logFilePath;
 		this._logToConsole = isServer;
 
 		this._minLogLevel = LogLevel.Warn;
 	}
 
-	public setup(consoleMinLogLevel: LogLevel, logToFile: boolean): void {
+	public setup(consoleMinLogLevel: LogLevel, logFilePath?: string): void {
 		this._minLogLevel = consoleMinLogLevel;
 
 		// Open a log file in the specified location. Overwritten on each run.
-		if (logToFile) {
+		if (logFilePath) {
 			this.log(`Verbose logs are written to:\n`, LogLevel.Warn);
-			this.log(this._logFilePath + '\n', LogLevel.Warn);
+			this.log(logFilePath + '\n', LogLevel.Warn);
 
-			this._logFileStream = fs.createWriteStream(this._logFilePath);
+			this._logFileStream = fs.createWriteStream(logFilePath);
 			this._logFileStream.on('error', e => {
-				this.sendLog(`Error involving log file at path: ${this._logFilePath}. Error: ${e.toString()}`, LogLevel.Error);
+				this.sendLog(`Error involving log file at path: ${logFilePath}. Error: ${e.toString()}`, LogLevel.Error);
 			});
 		}
 	}

--- a/adapter/src/loggingDebugSession.ts
+++ b/adapter/src/loggingDebugSession.ts
@@ -10,13 +10,13 @@ const logger = Logger.logger;
 import {DebugSession} from './debugSession';
 
 export class LoggingDebugSession extends DebugSession {
-	public constructor(obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean) {
+	public constructor(private obsolete_logFilePath: string, obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean) {
 		super(obsolete_debuggerLinesAndColumnsStartAt1, obsolete_isServer);
 	}
 
 	public start(inStream: NodeJS.ReadableStream, outStream: NodeJS.WritableStream): void {
 		super.start(inStream, outStream);
-		logger.init(e => this.sendEvent(e), this._isServer);
+		logger.init(e => this.sendEvent(e), this.obsolete_logFilePath, this._isServer);
 	}
 
 	/**

--- a/adapter/src/loggingDebugSession.ts
+++ b/adapter/src/loggingDebugSession.ts
@@ -10,13 +10,13 @@ const logger = Logger.logger;
 import {DebugSession} from './debugSession';
 
 export class LoggingDebugSession extends DebugSession {
-	public constructor(private _logFilePath: string, obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean) {
+	public constructor(obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean) {
 		super(obsolete_debuggerLinesAndColumnsStartAt1, obsolete_isServer);
 	}
 
 	public start(inStream: NodeJS.ReadableStream, outStream: NodeJS.WritableStream): void {
 		super.start(inStream, outStream);
-		logger.init(e => this.sendEvent(e), this._logFilePath, this._isServer);
+		logger.init(e => this.sendEvent(e), this._isServer);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #143

The real change is that instead of passing the log file path to the constructor of LoggingDebugSession, it should be passed later in `setup`. I don't know why I did it that way to start out with, since the log file isn't created until `setup` happens anyway.

This would technically be a breaking change to the logger/LoggingDebugSession, but I'm not sure whether anybody is using it. Just in case, I've patched it up to allow keeping the same API. I would prefer to clean it up, but I assume there are other breaking changes that we are sitting on that can wait until something like 2.0. Thoughts?