### PR TITLE
Fix #187 - implement async dispose() on logger

### DIFF
--- a/adapter/src/logger.ts
+++ b/adapter/src/logger.ts
@@ -35,6 +35,10 @@ export class Logger {
 	private _currentLogger: InternalLogger;
 	private _pendingLogQ: ILogItem[] = [];
 
+	constructor() {
+		process.on('exit', () => this.dispose());
+	}
+
 	log(msg: string, level = LogLevel.Log): void {
 		msg = msg + '\n';
 		this._write(msg, level);
@@ -52,6 +56,16 @@ export class Logger {
 		this.log(msg, LogLevel.Error);
 	}
 
+	dispose(): Promise<void> {
+		if (this._currentLogger) {
+			const disposeP = this._currentLogger.dispose();
+			this._currentLogger = null;
+			return disposeP;
+		} else {
+			return Promise.resolve();
+		}
+	}
+
 	/**
 	 * `log` adds a newline, `write` doesn't
 	 */
@@ -60,7 +74,7 @@ export class Logger {
 		msg = msg + '';
 		if (this._pendingLogQ) {
 			this._pendingLogQ.push({ msg, level });
-		} else {
+		} else if (this._currentLogger) {
 			this._currentLogger.log(msg, level);
 		}
 	}
@@ -147,6 +161,17 @@ class InternalLogger {
 				}
 			}
 		}
+	}
+
+	public dispose(): Promise<void> {
+		return new Promise(resolve => {
+			if (this._logFileStream) {
+				this._logFileStream.end(resolve);
+				this._logFileStream = null;
+			} else {
+				resolve();
+			}
+		});
 	}
 
 	public log(msg: string, level: LogLevel): void {


### PR DESCRIPTION
Should it be called `close` or `end` or something else? `dispose` is always sync in vscode, is that not the proper term for async cleanup?