### PR TITLE
Fixing wrong signature of terminateThreadsRequest

### DIFF
--- a/adapter/src/debugSession.ts
+++ b/adapter/src/debugSession.ts
@@ -714,7 +714,7 @@ export class DebugSession extends ProtocolServer {
 		this.sendResponse(response);
 	}
 
-	protected terminateThreadsRequest(response: DebugProtocol.TerminateThreadsResponse, args: DebugProtocol.TerminateThreadsRequest): void {
+	protected terminateThreadsRequest(response: DebugProtocol.TerminateThreadsResponse, args: DebugProtocol.TerminateThreadsArguments): void {
 		this.sendResponse(response);
 	}
 


### PR DESCRIPTION
Args should be of type TerminateThreadsArguments not TerminateThreadsRequest