### PR TITLE
Now we only write messages based on the loggin glevel

### DIFF
--- a/adapter/src/logger.ts
+++ b/adapter/src/logger.ts
@@ -224,7 +224,8 @@ class InternalLogger {
 			return;
 		}
 
-		if (level >= this._minLogLevel) {
+		const shouldBeLogged: boolean = level >= this._minLogLevel;
+		if (shouldBeLogged) {
 			this.sendLog(msg, level);
 		}
 
@@ -248,7 +249,7 @@ class InternalLogger {
 			msg = '[' + getFormattedTimeString() + '] ' + msg;
 		}
 
-		if (this._logFileStream) {
+		if (this._logFileStream && shouldBeLogged) {
 			this._logFileStream.write(msg);
 		}
 	}


### PR DESCRIPTION
Before this change all messages were written to the file, so even thought we specified "info" level sometimes, we were still getting all the "verbose" messages in the log file.