### PR TITLE
Added option to not log the output of an OutputEvent

### DIFF
--- a/adapter/src/loggingDebugSession.ts
+++ b/adapter/src/loggingDebugSession.ts
@@ -7,7 +7,7 @@ import {DebugProtocol} from 'vscode-debugprotocol';
 
 import * as Logger from './logger';
 const logger = Logger.logger;
-import {DebugSession} from './debugSession';
+import {DebugSession, OutputEvent} from './debugSession';
 
 export class LoggingDebugSession extends DebugSession {
 	public constructor(private obsolete_logFilePath?: string, obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean) {
@@ -29,7 +29,14 @@ export class LoggingDebugSession extends DebugSession {
 	public sendEvent(event: DebugProtocol.Event): void {
 		if (!(event instanceof Logger.LogOutputEvent)) {
 			// Don't create an infinite loop...
-			logger.verbose(`To client: ${JSON.stringify(event)}`);
+
+			let objectToLog = event;
+			if (event instanceof OutputEvent && event.body && event.body.data && event.body.data.doNotLogOutput) {
+				objectToLog = { ...event };
+				objectToLog.body = { ...event.body, output: '<output not logged>' }
+			}
+
+			logger.verbose(`To client: ${JSON.stringify(objectToLog)}`);
 		}
 
 		super.sendEvent(event);

--- a/adapter/src/loggingDebugSession.ts
+++ b/adapter/src/loggingDebugSession.ts
@@ -32,6 +32,7 @@ export class LoggingDebugSession extends DebugSession {
 
 			let objectToLog = event;
 			if (event instanceof OutputEvent && event.body && event.body.data && event.body.data.doNotLogOutput) {
+				delete event.body.data.doNotLogOutput;
 				objectToLog = { ...event };
 				objectToLog.body = { ...event.body, output: '<output not logged>' }
 			}


### PR DESCRIPTION
Added option to not log the output of an OutputEvent

on chrome-debug-core we output the script's source files when we get a .scripts <url> event. The scritp's source is customer content, so we should do our best to not log it, in case the user submits an issue and attachets the log. To avoid logging we added this doNotLogOutput option that we'll specify on chrome-debug-core to not log the output.

This flag is used in: https://github.com/microsoft/vscode-chrome-debug-core/pull/518