### PR TITLE
Removed unused production dependency on mkdirp

### DIFF
--- a/adapter/package-lock.json
+++ b/adapter/package-lock.json
@@ -4,15 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/mkdirp": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
-			"integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/mocha": {
 			"version": "5.2.5",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
@@ -152,6 +143,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}

--- a/adapter/package.json
+++ b/adapter/package.json
@@ -14,11 +14,9 @@
 	"main": "./lib/main.js",
 	"typings": "./lib/main",
 	"dependencies": {
-		"mkdirp": "^0.5.1",
 		"vscode-debugprotocol": "1.37.0"
 	},
 	"devDependencies": {
-		"@types/mkdirp": "^0.5.2",
 		"@types/node": "8.9.3",
 		"@types/mocha": "5.2.5",
 		"mocha": "5.2.0",


### PR DESCRIPTION
Signed-off-by: Rob Moran <github@thegecko.org>

As far as I can tell, `mkdirp` is no longer used by the `vscode-debugadapter` package.

This PR removes the dependency.