### PR TITLE
testsupport: add send/recv events

### DIFF
--- a/testSupport/README.md
+++ b/testSupport/README.md
@@ -14,6 +14,8 @@ var dc: DebugClient;
 
 setup( () => {
     dc = new DebugClient('node', './out/node/nodeDebug.js', 'node');
+	dc.on("send", (body: string) =>  console.log("send>>> " + body))
+	dc.on("recv", (body: string) =>  console.log("recv<<< " + body))
     return dc.start();
 });
 

--- a/testSupport/src/protocolClient.ts
+++ b/testSupport/src/protocolClient.ts
@@ -94,6 +94,7 @@ export class ProtocolClient extends ee.EventEmitter {
 		this.pendingRequests.set(request.seq, clb);
 
 		const json = JSON.stringify(request);
+		this.emit("send", json);
 		this.outputStream.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`, 'utf8');
 	}
 
@@ -132,7 +133,7 @@ export class ProtocolClient extends ee.EventEmitter {
 	}
 
 	private dispatch(body: string): void {
-
+		this.emit("recv", body);
 		const rawData = JSON.parse(body);
 
 		if (typeof rawData.event !== 'undefined') {


### PR DESCRIPTION
This PR add new events "send" and "recv" on DebugClient.ts. Now we can listen to these events to print messages to stdout or in a file to troubleshot failed tests.