### PR TITLE
Change new Buffer(0) to Buffer.alloc(0) to prevent deprecation warning

### DIFF
--- a/adapter/src/protocol.ts
+++ b/adapter/src/protocol.ts
@@ -123,7 +123,7 @@ export class ProtocolServer extends ee.EventEmitter implements VSCodeDebugAdapte
 	public start(inStream: NodeJS.ReadableStream, outStream: NodeJS.WritableStream): void {
 		this._sequence = 1;
 		this._writableStream = outStream;
-		this._rawData = new Buffer(0);
+		this._rawData = Buffer.alloc(0);
 
 		inStream.on('data', (data: Buffer) => this._handleData(data));
 

--- a/testSupport/src/protocolClient.ts
+++ b/testSupport/src/protocolClient.ts
@@ -14,7 +14,7 @@ export class ProtocolClient extends ee.EventEmitter {
 	private outputStream: stream.Writable;
 	private sequence: number;
 	private pendingRequests = new Map<number, (e: DebugProtocol.Response) => void>();
-	private rawData = new Buffer(0);
+	private rawData = Buffer.alloc(0);
 	private contentLength: number;
 
 	constructor() {


### PR DESCRIPTION
The old `Buffer(x)` API is deprecated and produces a warning. The equivalent new API is `Buffer.alloc` (strictly for non-zero lengths `Buffer.allocUnsafe` is the same, but probably not what most people should use).

https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1

Fixes #217.
