### PR TITLE
Fixed links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Debug adapter protocol and default implementation for VS Code.
 This repository contains the code for the following npm modules:
 
 * _vscode-debugprotocol_: Npm module with declarations for the json-based VS Code debug protocol.<br>
-[![NPM Version](https://img.shields.io/npm/v/vscode-debugprotocol.svg)](https://npmjs.org/package/vscode-debugprotocol)
-[![NPM Downloads](https://img.shields.io/npm/dm/vscode-debugprotocol.svg)](https://npmjs.org/package/vscode-debugprotocol)
+[![NPM Version](https://img.shields.io/npm/v/@vscode/debugprotocol.svg)](https://npmjs.org/package/@vscode/debugprotocol)
+[![NPM Downloads](https://img.shields.io/npm/dm/@vscode/debugprotocol.svg)](https://npmjs.org/package/@vscode/debugprotocol)
 * _vscode-debugadapter_: Npm module to implement a VS Code debug adapter using Node.js as a runtime.<br>
-[![NPM Version](https://img.shields.io/npm/v/vscode-debugadapter.svg)](https://npmjs.org/package/vscode-debugadapter)
-[![NPM Downloads](https://img.shields.io/npm/dm/vscode-debugadapter.svg)](https://npmjs.org/package/vscode-debugadapter)
+[![NPM Version](https://img.shields.io/npm/v/@vscode/debugadapter.svg)](https://npmjs.org/package/@vscode/debugadapter)
+[![NPM Downloads](https://img.shields.io/npm/dm/@vscode/debugadapter.svg)](https://npmjs.org/package/@vscode/debugadapter)
 * _vscode-debugadapter-testsupport_: Npm module with support classes for testing VS Code debug adapters.<br>
-[![NPM Version](https://img.shields.io/npm/v/vscode-debugadapter-testsupport.svg)](https://npmjs.org/package/vscode-debugadapter-testsupport)
-[![NPM Downloads](https://img.shields.io/npm/dm/vscode-debugadapter-testsupport.svg)](https://npmjs.org/package/vscode-debugadapter-testsupport)
+[![NPM Version](https://img.shields.io/npm/v/@vscode/debugadapter-testsupport.svg)](https://npmjs.org/package/@vscode/debugadapter-testsupport)
+[![NPM Downloads](https://img.shields.io/npm/dm/@vscode/debugadapter-testsupport.svg)](https://npmjs.org/package/@vscode/debugadapter-testsupport)
 
 ## License
 


### PR DESCRIPTION
Links were previously leading to the deprecated packages