### PR TITLE
fix: sendError() doesn't throw an error anymore when no format is specified

### DIFF
--- a/adapter/src/debugSession.ts
+++ b/adapter/src/debugSession.ts
@@ -462,7 +462,7 @@ export class DebugSession extends ProtocolServer {
 		if (typeof codeOrMessage === 'number') {
 			msg = <DebugProtocol.Message> {
 				id: <number> codeOrMessage,
-				format: format
+				format: format ? format : ''
 			};
 			if (variables) {
 				msg.variables = variables;


### PR DESCRIPTION
As an example, the following code would send an error:
```
class CustomDebugSession extends DebugSession {
  protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
    this.sendErrorResponse(response, 100);
  }
}
```
The error in question: `Uncaught Error Error: TypeError: Cannot read properties of undefined (reading 'replace')`

This is due to the method _sendErrorResponse()_ calling _formatPII()_ even though no format is passed to the former.
The solution adopted was to assign an empty string as the format if none was passed as an argument. Another solution could be to make the format argument mandatory.
