### PR TITLE
fix: update peer dependency versions

### DIFF
--- a/adapter/package.json
+++ b/adapter/package.json
@@ -21,7 +21,7 @@
 	},
 	"typings": "./lib/main",
 	"dependencies": {
-		"@vscode/debugprotocol": "1.58.0"
+		"@vscode/debugprotocol": "1.59.0"
 	},
 	"devDependencies": {
 		"@types/mocha": "^9.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 			"version": "1.59.0",
 			"license": "MIT",
 			"dependencies": {
-				"@vscode/debugprotocol": "1.58.0"
+				"@vscode/debugprotocol": "1.59.0"
 			},
 			"devDependencies": {
 				"@types/mocha": "^9.1.0",
@@ -1009,7 +1009,7 @@
 			"version": "1.59.0",
 			"license": "MIT",
 			"dependencies": {
-				"@vscode/debugprotocol": "1.58.0"
+				"@vscode/debugprotocol": "1.59.0"
 			},
 			"devDependencies": {
 				"@types/node": "14.x",
@@ -1043,7 +1043,7 @@
 			"version": "file:adapter",
 			"requires": {
 				"@types/mocha": "^9.1.0",
-				"@vscode/debugprotocol": "1.58.0",
+				"@vscode/debugprotocol": "1.59.0",
 				"mocha": "^9.2.1",
 				"typescript": "^4.9.4"
 			}
@@ -1052,7 +1052,7 @@
 			"version": "file:testSupport",
 			"requires": {
 				"@types/node": "14.x",
-				"@vscode/debugprotocol": "1.58.0",
+				"@vscode/debugprotocol": "1.59.0",
 				"typescript": "^4.9.4"
 			}
 		},

--- a/testSupport/package.json
+++ b/testSupport/package.json
@@ -17,7 +17,7 @@
 	"main": "./lib/main.js",
 	"typings": "./lib/main",
 	"dependencies": {
-		"@vscode/debugprotocol": "1.58.0"
+		"@vscode/debugprotocol": "1.59.0"
 	},
 	"devDependencies": {
 		"@types/node": "14.x",


### PR DESCRIPTION
This was blocking publishing. I thought npm did this automatically when calling 'version', will need to investigate