### PR TITLE
Change namespace to use `namespace` keyword.

### DIFF
--- a/protocol/src/generator.ts
+++ b/protocol/src/generator.ts
@@ -21,7 +21,7 @@ function Module(moduleName: string, schema: IProtocol): string {
 	//s += comment(schema.description);
 	s += comment({ description: 'Declaration module describing the VS Code debug protocol.\nAuto-generated from json schema. Do not edit manually.'});
 
-	s += openBlock(`export declare module ${moduleName}`);
+	s += openBlock(`export declare namespace ${moduleName}`);
 
 	for (let typeName in schema.definitions) {
 


### PR DESCRIPTION
The `module` keyword is deprecated in TypeScript 6.0, and will no longer work in TypeScript 7.

Discovered in https://github.com/microsoft/vscode-copilot-chat/pull/4272